### PR TITLE
Updates to fix issues #54 and #63

### DIFF
--- a/cleaning_codes/get_ai.R
+++ b/cleaning_codes/get_ai.R
@@ -247,7 +247,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_dfo-hs.R
+++ b/cleaning_codes/get_dfo-hs.R
@@ -230,7 +230,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_dfo-qcs.R
+++ b/cleaning_codes/get_dfo-qcs.R
@@ -239,7 +239,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_dfo-sog.R
+++ b/cleaning_codes/get_dfo-sog.R
@@ -250,7 +250,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_dfo-wchg.R
+++ b/cleaning_codes/get_dfo-wchg.R
@@ -254,7 +254,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_dfo-wcvi.R
+++ b/cleaning_codes/get_dfo-wcvi.R
@@ -237,7 +237,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_ebs.R
+++ b/cleaning_codes/get_ebs.R
@@ -157,7 +157,7 @@ ebs <- ebs %>%
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_gmex.R
+++ b/cleaning_codes/get_gmex.R
@@ -423,7 +423,7 @@ gmex <- gmex %>%
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_goa.R
+++ b/cleaning_codes/get_goa.R
@@ -217,7 +217,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_gsl-n.R
+++ b/cleaning_codes/get_gsl-n.R
@@ -214,7 +214,7 @@ GSLnor <- GSLnor %>%
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_gsl-s.R
+++ b/cleaning_codes/get_gsl-s.R
@@ -138,7 +138,7 @@ GSLsouth <- GSLsouth %>%
 #--------------------------------------------------------------------------------------#
 
 # Get WoRMS id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_neus.R
+++ b/cleaning_codes/get_neus.R
@@ -9,10 +9,6 @@
 ####Zoe Kitchel
 #### May 4, 2024
 ####Following issue 47, need to update sum technique to remove duplicates
-####Update
-####Juliano Palacios
-#### September 11, 2025
-####Following issue 54, fixing negative values of `num_cpue` and `wgt_cpue`
 ################################################################################
 
 
@@ -563,8 +559,6 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-# `gnr_datasources()` was deprecated in taxize v0.9.102.
-# ℹ Please use `gna_data_sources()` instead.
 wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
@@ -632,7 +626,7 @@ unique_name_match <- count_clean_neus %>%
 unique_name_match
 #check if empty
 
-
+clean_neus
 
 # -------------------------------------------------------------------------------------#
 #### SAVE DATABASE IN GOOGLE DRIVE ####
@@ -774,5 +768,5 @@ for(i in 1:length(survey_units)){
 
 
 # Just run this routine should be good for all
-write_clean_data(data = survey_std, survey = "NEUS_std",
-                 overwrite = T, rdata=TRUE)
+# write_clean_data(data = survey_std, survey = "NEUS_std",
+                 # overwrite = T, rdata=TRUE)

--- a/cleaning_codes/get_neus.R
+++ b/cleaning_codes/get_neus.R
@@ -9,6 +9,10 @@
 ####Zoe Kitchel
 #### May 4, 2024
 ####Following issue 47, need to update sum technique to remove duplicates
+####Update
+####Juliano Palacios
+#### September 11, 2025
+####Following issue 54, fixing negative values of `num_cpue` and `wgt_cpue`
 ################################################################################
 
 
@@ -559,7 +563,9 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+# `gnr_datasources()` was deprecated in taxize v0.9.102.
+# ℹ Please use `gna_data_sources()` instead.
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_norway.R
+++ b/cleaning_codes/get_norway.R
@@ -39,7 +39,7 @@ library(RODBC)
 library(here)
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_scs.R
+++ b/cleaning_codes/get_scs.R
@@ -249,7 +249,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_seus.R
+++ b/cleaning_codes/get_seus.R
@@ -328,7 +328,7 @@ unique_name_match <- count_seus %>%
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_wcann.R
+++ b/cleaning_codes/get_wcann.R
@@ -265,7 +265,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/cleaning_codes/get_wctri.R
+++ b/cleaning_codes/get_wctri.R
@@ -245,7 +245,7 @@ unique_name_match
 #--------------------------------------------------------------------------------------#
 
 # Get WoRM's id for sourcing
-wrm <- gnr_datasources() %>% 
+wrm <- gna_data_sources() %>% 
   filter(title == "World Register of Marine Species") %>% 
   pull(id)
 

--- a/functions/clean_taxa.R
+++ b/functions/clean_taxa.R
@@ -174,17 +174,16 @@ clean_taxa <- function(taxon_list, input_survey = "NA", save = F, output = NA, f
     # NOTE: it takes longer because it goes trough a
     # series of checkpoints a taxon validation
     
-    
-    # If scientific names are provided, check misspelling
-    fix_taxon <- taxize::gnr_resolve(taxon_list,
+    fix_taxon <- taxize::gna_verifier(taxon_list,
                                      data_source_ids = wrm,
                                      best_match_only = TRUE,
                                      canonical = TRUE,
                                      ask = FALSE) %>%
       # dplyr::filter(score > 0.98) %>%
       dplyr::select(
-        query = user_supplied_name,
-        taxa = matched_name2)
+        query = submittedName,
+        taxa = matchedCanonicalSimple
+        )
     
     # # Missing in fix_taxon
     missing_misspelling <- tibble::tibble(

--- a/functions/clean_taxa.R
+++ b/functions/clean_taxa.R
@@ -51,8 +51,11 @@
 
 # Test for misspelled species
 # taxa <- c("Gadus morhua","plop", "Thunus alalonga","Octopus vulgaris")
+taxon_list <- c(126436,765, 127026,140605)
 # # Call function
-# clean_taxa(taxon_list = taxa, input_survey = "Test", save = F, output = "")
+clean_taxa(taxon_list = taxa, input_survey = "Test", save = F, output = "")
+
+
 
 # OUTPUT
 # Time difference of -3.160841 secs
@@ -62,18 +65,6 @@
 # ------------#
 # Function
 # ------------#
-
-# Example of use
-
-# Needed variables
-taxon_list <- c("Gadus morhua","plop", "Thunnus alalunga","Octopus vulgaris")
-input_survey <- "test"
-save <- F
-output <- "NA"
-fishbase <- TRUE
-
-# Call function
-clean_taxa(taxon_list)
 
 
 ##### 

--- a/functions/clean_taxa.R
+++ b/functions/clean_taxa.R
@@ -5,6 +5,9 @@
 # Last Updated: August 2023
 # Update task: worms package is outdated, updating functions to use
 # worrms package instead.
+# Last Updated: September 2025
+# Update task: taxize package was updated, function needs to be 
+# updated accordingly
 # ------------------------------------------ #
 
 # ------------#
@@ -60,9 +63,20 @@
 # Function
 # ------------#
 
-# clean_taxa(taxon_list)
+# Example of use
 
-# taxon_list <- "Hemitripterus americanus"
+# Needed variables
+taxon_list <- c("Gadus morhua","plop", "Thunnus alalunga","Octopus vulgaris")
+input_survey <- "test"
+save <- F
+output <- "NA"
+fishbase <- TRUE
+
+# Call function
+clean_taxa(taxon_list)
+
+
+##### Function to clean taxa names and get fishbase ids
 
 clean_taxa <- function(taxon_list, input_survey = "NA", save = F, output = NA, fishbase=TRUE){
   

--- a/functions/clean_taxa.R
+++ b/functions/clean_taxa.R
@@ -51,9 +51,9 @@
 
 # Test for misspelled species
 # taxa <- c("Gadus morhua","plop", "Thunus alalonga","Octopus vulgaris")
-taxon_list <- c(126436,765, 127026,140605)
+# taxa <- c(126436,765, 127026,140605)
 # # Call function
-clean_taxa(taxon_list = taxa, input_survey = "Test", save = F, output = "")
+# clean_taxa(taxon_list = taxa, input_survey = "Test", save = F, output = "")
 
 
 

--- a/functions/clean_taxa.R
+++ b/functions/clean_taxa.R
@@ -76,7 +76,7 @@ fishbase <- TRUE
 clean_taxa(taxon_list)
 
 
-##### Function to clean taxa names and get fishbase ids
+##### 
 
 clean_taxa <- function(taxon_list, input_survey = "NA", save = F, output = NA, fishbase=TRUE){
   
@@ -95,7 +95,7 @@ clean_taxa <- function(taxon_list, input_survey = "NA", save = F, output = NA, f
   s_time <- Sys.time()
   
   # Get WoRM's id for sourcing
-  wrm <- taxize::gnr_datasources() %>% 
+  wrm <- taxize::gna_data_sources() %>% 
     dplyr::filter(title == "World Register of Marine Species") %>% 
     dplyr::pull(id)
   

--- a/outputs/Cleaned_data/.Rapp.history
+++ b/outputs/Cleaned_data/.Rapp.history
@@ -1,0 +1,2 @@
+load("/Users/jepa88/GitHub/my_FishGlob_data/outputs/Cleaned_data/AI_clean.RData")
+head(AI_clean.RData)


### PR DESCRIPTION
Issue #54 had flagged negative values in the GSL-N survey. These happened because of a miss calculation of the haul duration `Duree` between 11pm of one day and 00:00 of the next day (from the original dataset).

This is the chunk of the code that fix the issue
```
# Double check negative values
# There are  252 negative Duree values
sapply(GSLnor[, sapply(GSLnor, is.numeric)], function(x) sum(x < 0))  #252

# These are a miss calculation between 11pm of one day and 00:00 of the next day
fix_negatives <- GSLnor %>% 
  filter(Duree <0) %>% 
  mutate(
    t1 = hms(Hre_Deb),
    t2 = hms(Hre_Fin),
    t2 = if_else(t2 < t1, t2 + hours(24), t2), # handle next day
    Duree = as.numeric(t2 - t1, units = "mins")
  ) %>% 
  select(-t1,-t2)

# Re join the correct times

GSLnor <- GSLnor %>% 
  filter(Duree > 0) %>% # keep only positive Duree
  bind_rows(fix_negatives) # add the fixed negative values

### End of Fix (Update September 11, 2025) ##
```

Fix to issue #63  with taxize package. Simply changed functions on script. 


