### PR TITLE
patch for issue #49 -- haul_id columns now all characters, not numeric

### DIFF
--- a/cleaning_codes/get_gmex.R
+++ b/cleaning_codes/get_gmex.R
@@ -546,6 +546,20 @@ unique_name_match <- count_clean_gmex %>%
 #depend on goals of data use, and therefore are maintained in FishGlob data product
 
 
+
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(clean_gmex$haul_id) 
+head(clean_gmex$haul_id) 
+
+clean_gmex_fixed_haul_id <- clean_gmex |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(clean_gmex_fixed_haul_id$haul_id)
+head(clean_gmex_fixed_haul_id$haul_id)
+###########
+
+
+
+
 # -------------------------------------------------------------------------------------#
 #### SAVE DATABASE IN GOOGLE DRIVE ####
 # -------------------------------------------------------------------------------------#
@@ -683,6 +697,18 @@ for(i in 1:length(survey_units)){
 }
 
 
+
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(survey_std$haul_id) 
+head(survey_std$haul_id) 
+
+survey_std_fixed_haul_id <- survey_std |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(survey_std_fixed_haul_id$haul_id)
+head(survey_std_fixed_haul_id$haul_id)
+###########
+
+
 # Just run this routine should be good for all
-write_clean_data(data = survey_std, survey = "GMEX_std",
+write_clean_data(data = survey_std_fixed_haul_id, survey = "GMEX_std",
                  overwrite = T, rdata=TRUE)

--- a/cleaning_codes/get_neus.R
+++ b/cleaning_codes/get_neus.R
@@ -666,15 +666,27 @@ unique_name_match
 
 clean_neus
 
+
+
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(clean_neus$haul_id) 
+head(clean_neus$haul_id) 
+# this is a character, but still gets written out as a numeric, so let's make that impossible
+
+clean_neus_fixed_haul_id <- clean_neus |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(clean_neus_fixed_haul_id$haul_id)
+head(clean_neus_fixed_haul_id$haul_id)
+###########
+
+
 # -------------------------------------------------------------------------------------#
 #### SAVE DATABASE IN GOOGLE DRIVE ####
 # -------------------------------------------------------------------------------------#
 
 # Just run this routine should be good for all
-write_clean_data(data = clean_neus, survey = "NEUS", overwrite = T)
+write_clean_data(data = clean_neus_fixed_haul_id, survey = "NEUS", overwrite = T)
 
-write_clean_data(data = clean_neus, survey = "NEUS", overwrite = T,
-                 csv = T, rdata= F)
 
 
 # -------------------------------------------------------------------------------------#
@@ -805,6 +817,20 @@ for(i in 1:length(survey_units)){
 }
 
 
+
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(survey_std$haul_id) 
+head(survey_std$haul_id) 
+# this is a character, but still gets written out as a numeric, so let's make that impossible
+
+survey_std_fixed_haul_id <- survey_std |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(survey_std_fixed_haul_id$haul_id)
+head(survey_std_fixed_haul_id$haul_id)
+###########
+
+
 # Just run this routine should be good for all
-# write_clean_data(data = survey_std, survey = "NEUS_std",
-                 # overwrite = T, rdata=TRUE)
+write_clean_data(data = survey_std_fixed_haul_id, survey = "NEUS_std",
+                  overwrite = T, rdata=TRUE)
+

--- a/cleaning_codes/get_wcann.R
+++ b/cleaning_codes/get_wcann.R
@@ -360,12 +360,27 @@ unique_name_match
 #Sebastes                                  Sebastes     
 #Sebastes sp. (miniatus / crocotulus)      Sebastes     
 #Sebastes sp. (aleutianus / melanostictus) Sebastes 
+
+
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(clean_wcann$haul_id) 
+head(clean_wcann$haul_id) 
+# this is a numeric
+# could tell R to make it a character, but safer for it to not be a string of numbers anyway
+
+clean_wcann_fixed_haul_id <- clean_wcann |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(clean_wcann_fixed_haul_id$haul_id)
+head(clean_wcann_fixed_haul_id$haul_id)
+###########
+
+
 # -------------------------------------------------------------------------------------#
 #### SAVE DATABASE IN GOOGLE DRIVE ####
 # -------------------------------------------------------------------------------------#
 
 # Just run this routine should be good for all
-write_clean_data(data = clean_wcann, survey = "WCANN", overwrite = T, csv = T)
+write_clean_data(data = clean_wcann_fixed_haul_id, survey = "WCANN", overwrite = T, csv = T)
 
 
 
@@ -496,9 +511,20 @@ for(i in 1:length(survey_units)){
   }
 }
 
+########## A. Fredston, August 2025: resolving issue #49 where haul_id value is a numeric, see https://github.com/AquaAuma/FishGlob_data/issues/49 
+class(survey_std$haul_id) 
+head(survey_std$haul_id) 
+# this is a numeric
+# could tell R to make it a character, but safer for it to not be a string of numbers anyway
+
+survey_std_fixed_haul_id <- survey_std |> 
+  mutate(haul_id = paste0("id", haul_id))
+class(survey_std_fixed_haul_id$haul_id)
+head(survey_std_fixed_haul_id$haul_id)
+###########
 
 # Just run this routine should be good for all
-write_clean_data(data = survey_std, survey = "WCANN_std",
+write_clean_data(data = survey_std_fixed_haul_id, survey = "WCANN_std",
                  overwrite = T, rdata=TRUE)
 
 


### PR DESCRIPTION
fixing issue #49 where some regions had all-numeric haul_id values that got rounded in .csv file formats. they now have characters appended so they will always read/write as character columns.